### PR TITLE
DLPX-82095 Upgrade toolkits JDK to 8u345-b01 for 6.0.17.0

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,84 +19,167 @@
 	dh $@
 
 override_dh_install:
-	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u332b09.tar.gz" \
-		"0d902b24045e6e50ed025318ae712e2e518b3927e69228dd771feab612f822fe" \
-		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/jdk.tar.gz"
+	ifeq ("$(UPSTREAM_PRODUCT_BRANCH)", "master")
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz" \
+			"594530628100ea31ca39f4ae3728d9dbdeec5c6122fd70bc2880e675c3853f6d" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/jdk.tar.gz"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u332b09-manifest" \
-		"3ac180b43265938502053a02834f35504179ec57e70671c760aa262a10aba752" \
-		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/manifest"
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u345b01-manifest" \
+			"5710670e7c6327e734c4d1b6e8f4625120561c8aefb9b1aee1a595648cfa3352" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/manifest"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8_x64_Linux_jdk8u172-b11.tar.gz" \
-		"c8544a44c946aa971450e18bfa02a0741a986afd3d30c70ded2ea86c9743dac0" \
-		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8_172/jdk.tar.gz"
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8_x64_Linux_jdk8u172-b11.tar.gz" \
+			"c8544a44c946aa971450e18bfa02a0741a986afd3d30c70ded2ea86c9743dac0" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8_172/jdk.tar.gz"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8_x64_Linux_jdk8u172-b11-manifest" \
-		"a407c87a92df5e95901f23ddaffc2a0fb0e09e81835d1be98e0290d50b0b13c9" \
-		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8_172/manifest"
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8_x64_Linux_jdk8u172-b11-manifest" \
+			"a407c87a92df5e95901f23ddaffc2a0fb0e09e81835d1be98e0290d50b0b13c9" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8_172/manifest"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u332b09.tar.gz" \
-		"00302af3f1d1978d1c3975948513f69551ab4277e67f779880a14a0f2ab1d38e" \
-		"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/jdk.tar.gz"
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u345b01.tar.gz" \
+			"c96f4ee4d5caff2b663877b1edba519fbcc7479d9deda606d86450b51f4799ec" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/jdk.tar.gz"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u332b09-manifest" \
-		"ffbd69cdca3fef0906308dfae2e8c134f4b93b6cb80e93cb8260b2274560233c" \
-		"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/manifest"
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u345b01-manifest" \
+			"d74d01291133d5f359d6b7a4047b7b141bc4c24b0a223740169b4449b4a90d7a" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/manifest"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"aix/jdk1.8/jdk-8.0.0.706-aix-powerpc64.tar.gz" \
-		"61113aafa09222bc8fcd9a2f67207006639c1f9b383229624ce8365ad1917937" \
-		"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/jdk.tar.gz"
+		./scripts/fetch-file-from-artifactory.sh \
+			"aix/jdk1.8/jdk-8.0.0.711-aix-powerpc64.tar.gz" \
+			"7c61d2e66fb4609a8804fd3372850d14aeeca613e670379276bb3942aa00a24c" \
+			"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/jdk.tar.gz"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"aix/jdk1.8/jdk-8.0.0.706-aix-powerpc64-manifest" \
-		"700a7d17ef357209bf7859b348168256e8a799123ea06dd4f64b1a0d51af12f2" \
-		"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/manifest"
+		./scripts/fetch-file-from-artifactory.sh \
+			"aix/jdk1.8/jdk-8.0.0.711-aix-powerpc64-manifest" \
+			"bf3c33b0cb911a374308347a156f5e76814e1cd220c0a9783e9dfa33f5f55dac" \
+			"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/manifest"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"hpux/jdk1.8/jdk-8.0.23-hpux-ia64.tar.gz" \
-		"18c4aa183b551374a7b22a8eda3427d791a4869d3d797a61ae22bcc20451852d" \
-		"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/jdk.tar.gz"
+		./scripts/fetch-file-from-artifactory.sh \
+			"hpux/jdk1.8/jdk-8.0.24-hpux-ia64.tar.gz" \
+			"bc411257b93249dfe81e8000f5e115c060b641596054366ee84ab619c138d0af" \
+			"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/jdk.tar.gz"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"hpux/jdk1.8/jdk-8.0.23-hpux-ia64-manifest" \
-		"85e8bedda0e58310b31c038333546c902c5e8d58d169a385aa607647e281ef5d" \
-		"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/manifest"
+		./scripts/fetch-file-from-artifactory.sh \
+			"hpux/jdk1.8/jdk-8.0.24-hpux-ia64-manifest" \
+			"58fa98b26c0c13ad25325430e169fb32269eb9fa1a71294c8811014e1b8e81d9" \
+			"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/manifest"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u332b09.tar.gz" \
-		"3e8dad7d8987d3fac472f433e0b31b26197446cea8afdcf2850c9b1d1377ea9d" \
-		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk1.8/jdk.tar.gz"
+		./scripts/fetch-file-from-artifactory.sh \
+			"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u345b01.tar.gz" \
+			"6eab92d1a6cb1cf2736240375267bab8fb420ea452f46a752063af44c36866a9" \
+			"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk1.8/jdk.tar.gz"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u332b09-manifest" \
-		"f4df117004e6fd908597055dda89d4bc6c740bc66cbb205b8c4c578cf2116282" \
-		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk1.8/manifest"
+		./scripts/fetch-file-from-artifactory.sh \
+			"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u345b01-manifest" \
+			"f734fcfc262027d6622a49d27d18d76c631c88569b864aafb8b3650acadbb4e7" \
+			"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk1.8/manifest"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u322b06.tar.gz" \
-		"2f7b4d9495748bb3ebf5311b0cb4fbc06508b0d3ead7064ae6804d52d63a3ef9" \
-		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/jdk.tar.gz"
+		./scripts/fetch-file-from-artifactory.sh \
+			"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u345b01.tar.gz" \
+			"3f0222ab7451750a97bbcdd696fe1eb1520835a8edfa8577af0cbcf193a6b116" \
+			"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/jdk.tar.gz"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u322b06-manifest" \
-		"4d6d8ad850b66c1b87966e5e61cd46e6e43042070ab6c97345a7f031d6e1aaca" \
-		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/manifest"
+		./scripts/fetch-file-from-artifactory.sh \
+			"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u345b01-manifest" \
+			"fda28a5159664a62bbdf39f969b61336f9e4f42e21728ae5e24a0dc1dc2c5bdd" \
+			"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/manifest"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u332b09.zip" \
-		"53c2d909923c24197166d54cf3e0681401e67f535b3e9ef244ad8ac8da46819d" \
-		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/jdk.zip"
+		./scripts/fetch-file-from-artifactory.sh \
+			"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u345b01.zip" \
+			"62ce92ef5f3dd2ca082b834b9f3937d312b8ff370a23a3dfb2f701bfd90fc4d7" \
+			"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/jdk.zip"
 
-	./scripts/fetch-file-from-artifactory.sh \
-		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u332b09-manifest" \
-		"f452a2c76404fee98f50a0dc5d5e0e1dd8ce9ec39574e0cb17d7da8bab9a7e0b" \
-		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/manifest"
+		./scripts/fetch-file-from-artifactory.sh \
+			"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u345b01-manifest" \
+			"4ade5b4fa82767281329f35e6b7289ce7ec05500661610314442d7bc9931ffe5" \
+			"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/manifest"
+	else
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u332b09.tar.gz" \
+			"0d902b24045e6e50ed025318ae712e2e518b3927e69228dd771feab612f822fe" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/jdk.tar.gz"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u332b09-manifest" \
+			"3ac180b43265938502053a02834f35504179ec57e70671c760aa262a10aba752" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/manifest"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8_x64_Linux_jdk8u172-b11.tar.gz" \
+			"c8544a44c946aa971450e18bfa02a0741a986afd3d30c70ded2ea86c9743dac0" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8_172/jdk.tar.gz"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8_x64_Linux_jdk8u172-b11-manifest" \
+			"a407c87a92df5e95901f23ddaffc2a0fb0e09e81835d1be98e0290d50b0b13c9" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8_172/manifest"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u332b09.tar.gz" \
+			"00302af3f1d1978d1c3975948513f69551ab4277e67f779880a14a0f2ab1d38e" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/jdk.tar.gz"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u332b09-manifest" \
+			"ffbd69cdca3fef0906308dfae2e8c134f4b93b6cb80e93cb8260b2274560233c" \
+			"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/manifest"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"aix/jdk1.8/jdk-8.0.0.706-aix-powerpc64.tar.gz" \
+			"61113aafa09222bc8fcd9a2f67207006639c1f9b383229624ce8365ad1917937" \
+			"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/jdk.tar.gz"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"aix/jdk1.8/jdk-8.0.0.706-aix-powerpc64-manifest" \
+			"700a7d17ef357209bf7859b348168256e8a799123ea06dd4f64b1a0d51af12f2" \
+			"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/manifest"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"hpux/jdk1.8/jdk-8.0.23-hpux-ia64.tar.gz" \
+			"18c4aa183b551374a7b22a8eda3427d791a4869d3d797a61ae22bcc20451852d" \
+			"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/jdk.tar.gz"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"hpux/jdk1.8/jdk-8.0.23-hpux-ia64-manifest" \
+			"85e8bedda0e58310b31c038333546c902c5e8d58d169a385aa607647e281ef5d" \
+			"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/manifest"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u332b09.tar.gz" \
+			"3e8dad7d8987d3fac472f433e0b31b26197446cea8afdcf2850c9b1d1377ea9d" \
+			"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk1.8/jdk.tar.gz"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u332b09-manifest" \
+			"f4df117004e6fd908597055dda89d4bc6c740bc66cbb205b8c4c578cf2116282" \
+			"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk1.8/manifest"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u322b06.tar.gz" \
+			"2f7b4d9495748bb3ebf5311b0cb4fbc06508b0d3ead7064ae6804d52d63a3ef9" \
+			"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/jdk.tar.gz"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u322b06-manifest" \
+			"4d6d8ad850b66c1b87966e5e61cd46e6e43042070ab6c97345a7f031d6e1aaca" \
+			"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/manifest"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u332b09.zip" \
+			"53c2d909923c24197166d54cf3e0681401e67f535b3e9ef244ad8ac8da46819d" \
+			"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/jdk.zip"
+
+		./scripts/fetch-file-from-artifactory.sh \
+			"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u332b09-manifest" \
+			"f452a2c76404fee98f50a0dc5d5e0e1dd8ce9ec39574e0cb17d7da8bab9a7e0b" \
+			"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/manifest"
+	endif
+
 
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
### Description
Update host JDKs to 8u33209 version for windows, Solaris x64 and linux ppc64lc latest available versions.

### Testing
orchestrator build - http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/3034/

corresponding jdk-archiver commit - https://github.com/delphix/jdk-archiver/pull/3