### PR TITLE
DLPX-90119 Upgrade toolkits' JDKs to latest version

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 #
-# Copyright 2021, 2023 Delphix
+# Copyright 2021, 2024 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@
 
 override_dh_install:
 	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz" \
-		"f71c6600547b472dcc8c58b2fb3d809c61e58705d1c81aa72ffbe9b8f17f5a51" \
+		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u402b06.tar.gz" \
+		"1ff6612aaf1fe67d8ee164c833c07f4c97cb27159b33a26226978f3a1bf591ba" \
 		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u382b05-manifest" \
-		"7d011671f10b0f99309f071c933a39d91584890c146bb3e4c94052268c15eae3" \
+		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u402b06-manifest" \
+		"b102b065b194ce7cbfd1df3f062b4ff2fda5e6a18874d1a5a3cf755dcda90b5b" \
 		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
@@ -40,63 +40,63 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8_172/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u382b05.tar.gz" \
-		"4428dc9b6ee50c9f31e13752e88b05a7873ee91ac0f895c94982a8df88cd9ba7" \
+		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u402b06.tar.gz" \
+		"8b983990c35d0b10431d99caa5d25d4ff0da61e1b0a857f5c670ecaa81f013df" \
 		"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u382b05-manifest" \
-		"81913d3c9bb4c65c3a2a03133181cc8cf167e01839b93b6c23aee2d898704266" \
+		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u402b06-manifest" \
+		"fba8839c4101f16db9a1ff9ae48f6cdea7a4e99a197567140a52d865e9d12298" \
 		"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"aix/jdk1.8/jdk-8.0.0.811-aix-powerpc64.tar.gz" \
-		"d8344d8567a014bc3b8f8bef5c5af3aedf46c4c6565f652e15d2b633edeb68f6" \
+		"aix/jdk1.8/jdk-8.0.0.821-aix-powerpc64.tar.gz" \
+		"5bd2e89eb0570df2dbc8cf3502f311a8acb37b2c488041b458f13c806c6792b0" \
 		"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"aix/jdk1.8/jdk-8.0.0.811-aix-powerpc64-manifest" \
-		"e04b292cc9cc62e95e3144d6ed9cf4bfbd092fa66e293b2d226011ad8bc56890" \
+		"aix/jdk1.8/jdk-8.0.0.821-aix-powerpc64-manifest" \
+		"db60cc480d3c34bf384838396cbde2073ee3cad463c208d4cbd94786d562aedc" \
 		"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"hpux/jdk1.8/jdk-8.0.26-hpux-ia64.tar.gz" \
-		"ee5c3e2776abfca85a89c6ecaad496265a7db271b2441bfe381912a55c915b2a" \
+		"hpux/jdk1.8/jdk-8.0.27-hpux-ia64.tar.gz" \
+		"0a08c1a6bc07ace20839e45c34a144be23ba0aca56c8bf50b29da2ef485a9d7f" \
 		"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"hpux/jdk1.8/jdk-8.0.26-hpux-ia64-manifest" \
-		"008b29c64691e6ac49f3e9ceb47b24ed008dc3735e9df9f1506142311d6b6595" \
+		"hpux/jdk1.8/jdk-8.0.27-hpux-ia64-manifest" \
+		"ed885914b8da7275fa3aeab202a73fb18cf7b3268f7c0489af8d016bb9794ce1" \
 		"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u382b05.tar.gz" \
-		"fb079293f3fdf0d4845b5eb7b8494dc133fef82634bfb33b3ec58519a29fcd8c" \
+		"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u402b06.tar.gz" \
+		"14bdbfa15813f7e94955863e93682e420cadc26f9c37ebb12a0204809551f674" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u382b05-manifest" \
-		"cd339e7cba57dbcf2638b607b6f72f014101ada3106b15af85348b76d1d717a1" \
+		"sunos/jdk1.8/OpenJDK8U-jdk_x64_solaris_hotspot_8u402b06-manifest" \
+		"d707e93a715d5b325b470af7d857f8c708a199f552025710633e86ba5305e883" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u382b05.tar.gz" \
-		"42142d3c9d3ac460934104cbe0fef9f8fcb022f728aa82ffe2776746853cc679" \
+		"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u402b06.tar.gz" \
+		"d1a3107487ae3b246ede7e8bb5e21574e90915513ea9902b0cb54b230f3ef1ca" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u382b05-manifest" \
-		"9e21b5a550d9265142ffc0d33259f853853b0e134f04c6ee1869746a12afd521" \
+		"sunos/jdk1.8/OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u402b06-manifest" \
+		"7de941a8aaa590883ab3a26d1a0ca1a94b9bacf4cf3380ec58741e2f0f275250" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u382b05.zip" \
-		"eade4221a276ce6488943349b563e8d127de96fde9dff943bbacf8d2857be1f5" \
+		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u402b06.zip" \
+		"85b78462866965318ad9db1e9b650dd0ebee0267ec20609ca2df5dbdd3656916" \
 		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/jdk.zip"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u382b05-manifest" \
-		"94a3d57b0350d2dc9452e722eb82998fcdb80fe4a995db8e8b09218e780ea4a8" \
+		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u402b06-manifest" \
+		"0726e6616a2d6c27a7c86cba997f55cc0c9bd92af5722497adb4afedf6acbeff" \
 		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/manifest"
 
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
# Description
Update the toolkit's JDKs to the 8u402b06 version.

Code changes

- Updated the java versions and SHA values. (take sha values from **delphix-java-packages** [artifactory](https://artifactory.delphix.com/ui/repos/tree/General/delphix-java-packages))

# Testing 
# Manual Testing

- Ran ab-pre-push and cloned image.
- Created environments in the latest image for  RHEL, solaris_sparcv9, solaris_x64, SUSE, windows, AIX, HPUX and checked jdk version of the toolkit - All are the latest as expected.


# Bonus

Corresponding review:
- https://github.com/https://github.com/delphix/jdk-archiver/pull/6
- https://github.com/delphix/dlpx-app-gate/pull/2070
