### PR TITLE
DLPX-91125 [Forwardport - DLPX-91111] Environment discovery fails for HP-UX hosts with exception exception.host.client.launch.failed

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -60,13 +60,13 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"hpux/jdk1.8/jdk-8.0.27-hpux-ia64.tar.gz" \
-		"0a08c1a6bc07ace20839e45c34a144be23ba0aca56c8bf50b29da2ef485a9d7f" \
+		"hpux/jdk1.8/jdk-8.0.26-hpux-ia64.tar.gz" \
+		"ee5c3e2776abfca85a89c6ecaad496265a7db271b2441bfe381912a55c915b2a" \
 		"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"hpux/jdk1.8/jdk-8.0.27-hpux-ia64-manifest" \
-		"ed885914b8da7275fa3aeab202a73fb18cf7b3268f7c0489af8d016bb9794ce1" \
+		"hpux/jdk1.8/jdk-8.0.26-hpux-ia64-manifest" \
+		"008b29c64691e6ac49f3e9ceb47b24ed008dc3735e9df9f1506142311d6b6595" \
 		"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \


### PR DESCRIPTION
[Jira](https://delphix.atlassian.net/browse/DLPX-91125)
Clean cherry pick of #31 
# Description
In 23.0.0.0, the hpux toolkit jdk was upgraded from "1.8.0.26-hp-ux" to "1.8.0.27-hp-ux" which resulted in error while env discovery
Caused by: java.lang.SecurityException: The jurisdiction policy files are not signed by the expected signer! (Policy files are specific per major JDK release.Ensure the correct version is installed.) 
This PR is raised to revert this jdk upgrade.

# Testing
Build: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8577/parameters/

# Manual Testing:

1. Created an image from ab-pre-push dcenter uploaded images
2. Setup that engine
3. Added an hpux env
4. And the env addition is successful
5. Validated the java version in the toolkit to be
```
$ java/jdk/bin/java -version
java version "1.8.0.26-hp-ux"
Java(TM) SE Runtime Environment (build 1.8.0.26-hp-ux-b1)
Java HotSpot(TM) Server VM (build 25.26-b1, mixed mode)
```