### PR TITLE
DLPX-91125  Environment discovery fails for HP-UX hosts with exception exception.host.client.launch.failed

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -61,12 +61,12 @@ override_dh_install:
 
 	./scripts/fetch-file-from-artifactory.sh \
 		"hpux/jdk1.8/jdk-8.0.27-hpux-ia64.tar.gz" \
-		"0a08c1a6bc07ace20839e45c34a144be23ba0aca56c8bf50b29da2ef485a9d7f" \
+		"76be14b469398a18dac067a7b4782e1330a1c7eef1ad9fb5f41ece0d4d52aa42" \
 		"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
 		"hpux/jdk1.8/jdk-8.0.27-hpux-ia64-manifest" \
-		"ed885914b8da7275fa3aeab202a73fb18cf7b3268f7c0489af8d016bb9794ce1" \
+		"075c525a1a31be190f880c301916e707d20a2ec0ebff8bec1fd93f4b0600866b" \
 		"debian/tmp/usr/share/host-jdks/jdk/hpux_ia64/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \


### PR DESCRIPTION
# Problem:

After upgrading Java minor version from 8.0.26 to 8.0.27 for HP-UX, there was an issue while adding HP-UX hosts in DE.
Java Error:


> 2024-05-14T06:26:22.450Z main ERROR Unable to locate appender "appender.opensource" for logger config "org.springframework"
> com.delphix.exception.DelphixFatalException: java.lang.ExceptionInInitializerError
> 	at com.delphix.exception.ExceptionUtil.getDelphixException(ExceptionUtil.java:161)
> 	at com.delphix.session.util.AbstractConnector.create(AbstractConnector.java:267)
> 	at com.delphix.session.util.AbstractConnector.create(AbstractConnector.java:194)
> 	at com.delphix.connector.client.ConnectorClientApplication.getNexus(ConnectorClientApplication.java:89)
> 	at com.delphix.host.dsp.core.SimpleClientApplication.init(SimpleClientApplication.java:45)
> 	at com.delphix.host.dsp.core.ClientMain.main(ClientMain.java:128)
> Caused by: java.lang.ExceptionInInitializerError
> 	at javax.crypto.Cipher.getInstance(Cipher.java:516)
> 	at sun.security.ssl.JsseJce.getCipher(JsseJce.java:189)
> 	at sun.security.ssl.SSLCipher.isTransformationAvailable(SSLCipher.java:483)
> 	at sun.security.ssl.SSLCipher.<init>(SSLCipher.java:472)
> 	at sun.security.ssl.SSLCipher.<clinit>(SSLCipher.java:81)
> 	at sun.security.ssl.CipherSuite.<clinit>(CipherSuite.java:64)
> 	at sun.security.ssl.SSLContextImpl.getApplicableSupportedCipherSuites(SSLContextImpl.java:345)
> 	at sun.security.ssl.SSLContextImpl.access$100(SSLContextImpl.java:46)
> 	at sun.security.ssl.SSLContextImpl$AbstractTLSContext.<clinit>(SSLContextImpl.java:575)
> 	at java.lang.Class.forName0(Native Method)
> 	at java.lang.Class.forName(Class.java:268)
> 	at java.security.Provider$Service.getImplClass(Provider.java:1736)
> 	at java.security.Provider$Service.newInstance(Provider.java:1694)
> 	at sun.security.jca.GetInstance.getInstance(GetInstance.java:236)
> 	at sun.security.jca.GetInstance.getInstance(GetInstance.java:164)
> 	at javax.net.ssl.SSLContext.getInstance(SSLContext.java:156)
> 	at com.delphix.session.ssl.SSLContextFactory.getSSLContext(SSLContextFactory.java:68)
> 	at com.delphix.session.ssl.SSLContextFactory.getSSLContext(SSLContextFactory.java:63)
> 	at com.delphix.session.ssl.SSLContextFactory.getClientContext(SSLContextFactory.java:59)
> 	at com.delphix.session.util.AbstractConnector.create(AbstractConnector.java:263)
> 	... 4 more
> Caused by: java.lang.SecurityException: Can not initialize cryptographic mechanism
> 	at javax.crypto.JceSecurity.<clinit>(JceSecurity.java:93)
> 	... 24 more
> Caused by: java.lang.SecurityException: The jurisdiction policy files are not signed by the expected signer! (Policy files are specific per major JDK release.Ensure the correct version is installed.)
> 	at javax.crypto.JarVerifier.verifyPolicySigned(JarVerifier.java:336)
> 	at javax.crypto.JceSecurity.loadPolicies(JceSecurity.java:378)
> 	at javax.crypto.JceSecurity.setupJurisdictionPolicies(JceSecurity.java:323)
> 	at javax.crypto.JceSecurity.access$000(JceSecurity.java:50)
> 	at javax.crypto.JceSecurity$1.run(JceSecurity.java:85)
> 	at java.security.AccessController.doPrivileged(Native Method)
> 	at javax.crypto.JceSecurity.<clinit>(JceSecurity.java:82)
> 	... 24 more
> 

# Analysis
Issue was due to extra incorrect policy related jars (local_policy.jar, US_export_policy.jar) were present in jre/lib/security directory of new Java.
As these policy filoes were not correct, this error was coming:
`The jurisdiction policy files are not signed by the expected signer! (Policy files are specific per major JDK release.Ensure the correct version is installed.
After removing these files, this error was resolved.

# Solution:

Created new java 8 tar file, validated by adding host with new java location.
Able to add host seamlessly.

# Testing

Tested **manually** after creating java in one hpux machine, and adding that host to environment by providing alternative java path.

**Testing with new image:**
triggered ab-pre-push job: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8678/
clone DE from image created by ab-pre-push.
Added HP-UX host successfully.
Validated java version in toolkit.

