### PR TITLE
DLPX-94429 [host-jdks] Host JDK upgrade to JDK 8u452

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,13 +20,13 @@
 
 override_dh_install:
 	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u442b06.tar.gz" \
-		"0ec493ae7ca1fec9065df1855658a274540bc06ab608a7f671a5bc56abe292fa" \
+		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz" \
+		"599d8b40914a3abb8061f47f91e5d6ff060da4e81d3049564a47ceae9d4608f1" \
 		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u442b06-manifest" \
-		"c1fb0557edc6e02119f51c182ff49c34afc5033ab4c950ce9575ff4cbb4493e2" \
+		"linux/jdk1.8/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09-manifest" \
+		"8131e57eccf55e293b4d6f542b7d71cf51756b88802240e693aa15287f06dcca" \
 		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
@@ -40,13 +40,13 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/linux_x86/jdk1.8_172/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u442b06.tar.gz" \
-		"1403a3168bf6a477a5a237a4ffa1571befeb019f6ae73fc08d4fc3d39cd6d68d" \
+		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u452b09.tar.gz" \
+		"f4244036c5ee0cffd118b2dcd9afd00e99d646fa57575e25e08b82aae9e1aa52" \
 		"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u442b06-manifest" \
-		"83d3fd17b6877552a2732fbb8633ec73fd3dbafdf8bc5e2e5b07893397a1db89" \
+		"linux/jdk1.8/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u452b09-manifest" \
+		"6b6db7f2e65f73d58e6c57d4a4ee6081da284fb7ffcf4c89b6e1a2c27901e1df" \
 		"debian/tmp/usr/share/host-jdks/jdk/linux_ppc64le/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
@@ -60,13 +60,13 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/linux_s390x/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"aix/jdk1.8/jdk-8.0.0.840-aix-powerpc64.tar.gz" \
-		"fa8d316dde1410d369a125b14677892a541eb430bd53fc01cb42ca0503473fd9" \
+		"aix/jdk1.8/jdk-8.0.0.845-aix-powerpc64.tar.gz" \
+		"58203e55df5209bb6b599586e6086fb7f431decb59114425ac84d651c0b60296" \
 		"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"aix/jdk1.8/jdk-8.0.0.840-aix-powerpc64-manifest" \
-		"bbb8f8e20bd8dc9c3852b1f1634fad45cbcc7556c03f98f726413a80d817d0ca" \
+		"aix/jdk1.8/jdk-8.0.0.845-aix-powerpc64-manifest" \
+		"c3db203c5b69dab26ae4a035fda9f627a9047048c5119578e870885d52df67ae" \
 		"debian/tmp/usr/share/host-jdks/jdk/aix_powerpc/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
@@ -100,13 +100,13 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk1.8/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u442b06.zip" \
-		"4fec2aeb1cebe4bec0a2a1f5ed9415035f524a011d927a86001fb9f0c1462139" \
+		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u452b09.zip" \
+		"467a32fe8772522c9c6483b9040108264c5530b0e83dff2f9524fda265a7483e" \
 		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/jdk.zip"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u442b06-sha256manifest" \
-		"ebb269050eaea724e6fbdc975791a49c453abb0884de7faf5bc6ec4b391ae5ce" \
+		"windows/jdk1.8/OpenJDK8U-jdk_x64_windows_hotspot_8u452b09-sha256manifest" \
+		"a18eee98d790ff58759137c5d4f8d5c97d572f2ad7319f118061528f3b4406d1" \
 		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk1.8/manifest"
 
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
Vulnerability with jdk-8u442, upgrading to latest 8u452b09 version

# Solution:
Updated the toolkit's JDKs to the 8u452b09 version.

# Testing
ab-pre-push : https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11365/
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11399/
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11430/
app-gate PR : https://github.com/delphix/dlpx-app-gate/pull/3238/
Tested AIX, Linux & Windows hosts to make sure correct tookit jdk version is installed and created VDB from each env.

Cloned the engine from the JDK changes, added the precheckin src and tgt, and created a VDB from the same source used in blackbox testing. Verified that after stopping and starting the engine, all VDBs are running successfully.
![image](https://github.com/user-attachments/assets/8c4b2dc2-9033-4a6b-a64e-bf4dabca504c)


<!--
# Implementation:
The implementation details of the solution.
-->

# Notes To Reviewers:
Solaris & HPUX doesn't have the latest jdk available at this moment. We will keep monitoring and update them when they are available.

<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
