### PR TITLE
DLPX-96987 [solaris] Update host-jdk code to pick right JDK

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -70,22 +70,22 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk17/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk17u-jdk-17.0.18-ga.tar.gz" \
-		"76f7bce8f56d0c06936d6f8eb524e371cd6e0dee86231444f7897298e5abe77e" \
+		"sunos/jdk17/jdk-17u18-solaris-sparcv9.tar.gz" \
+		"82a187a8617042fe7d8827da0f13ea17cc4cf0731a53c7c1167a2d4070af23db" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-manifest" \
+		"sunos/jdk17/jdk-17u18-solaris-sparcv9-manifest" \
 		"573884e145756cc4d105f4c6964c5c0428ad0178dcd5d00c2e6288ce13ab1d66" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-x86-1.tar.gz" \
-		"5352423fb1e88c4f168b9fd083a519b905ad8d4762cf053f7e4488155b90e1d7" \
+		"sunos/jdk17/jdk-17u18-solaris-x64.tar.gz" \
+		"86d5f280d49796099746b0bd80bb30025cecc13a7a8079d9a6e014b53aa0c90d" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-x86-1-manifest" \
+		"sunos/jdk17/jdk-17u18-solaris-x64-manifest" \
 		"3fff2e27a12f7d2aed8852f8f7c3d7d68fea4169e1c77b7652c0aa6f4bc8b7a2" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/manifest"
 

--- a/debian/rules
+++ b/debian/rules
@@ -70,23 +70,23 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk17/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk-17u18-solaris-sparcv9.tar.gz" \
-		"82a187a8617042fe7d8827da0f13ea17cc4cf0731a53c7c1167a2d4070af23db" \
+		"sunos/jdk17/jdk-17u19-solaris-sparcv9.tar.gz" \
+		"467a68ee6b134efe787eb269efd39ae7e12c0bf40cb51819d83c7ea9a95a7a30" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk-17u18-solaris-sparcv9-manifest" \
-		"573884e145756cc4d105f4c6964c5c0428ad0178dcd5d00c2e6288ce13ab1d66" \
+		"sunos/jdk17/jdk-17u19-solaris-sparcv9-manifest" \
+		"e33e3dafc02fee7e264bf00ace91b0ec38cbe3cb8d1d765ae7bc2da676c6c37b" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk-17u18-solaris-x64.tar.gz" \
-		"86d5f280d49796099746b0bd80bb30025cecc13a7a8079d9a6e014b53aa0c90d" \
+		"sunos/jdk17/jdk-17u19-solaris-x64.tar.gz" \
+		"2e51fd6d6960c212e67c7e20928fc887e072663f9dbe3aca2161ffa4cc381c01" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk-17u18-solaris-x64-manifest" \
-		"3fff2e27a12f7d2aed8852f8f7c3d7d68fea4169e1c77b7652c0aa6f4bc8b7a2" \
+		"sunos/jdk17/jdk-17u19-solaris-x64-manifest" \
+		"28618d5db65de6455cd2fde98e958c0ca6528b86840fde2b4d048f0f24dfe3ff" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/manifest"
 
 	dh_install --autodest "debian/tmp/*"

--- a/debian/rules
+++ b/debian/rules
@@ -70,22 +70,22 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk17/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk-17u19-solaris-sparcv9.tar.gz" \
-		"467a68ee6b134efe787eb269efd39ae7e12c0bf40cb51819d83c7ea9a95a7a30" \
+		"sunos/jdk17/jdk17u-jdk_sparcv9_solaris_17.0.19.tar.gz" \
+		"8ed6180ec894212fc569878be791e5fb45fb8481dc09a82c56ba3b098e5567f7" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk-17u19-solaris-sparcv9-manifest" \
+		"sunos/jdk17/jdk17u-jdk_sparcv9_solaris_17.0.19-manifest" \
 		"e33e3dafc02fee7e264bf00ace91b0ec38cbe3cb8d1d765ae7bc2da676c6c37b" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk-17u19-solaris-x64.tar.gz" \
-		"2e51fd6d6960c212e67c7e20928fc887e072663f9dbe3aca2161ffa4cc381c01" \
+		"sunos/jdk17/jdk17u-jdk_x64_solaris_17.0.19.tar.gz" \
+		"47197001a3eabc6e348952071b5544cb3eed10732cc27d7aa8d9d8d5586c349e" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk-17u19-solaris-x64-manifest" \
+		"sunos/jdk17/jdk17u-jdk_x64_solaris_17.0.19-manifest" \
 		"28618d5db65de6455cd2fde98e958c0ca6528b86840fde2b4d048f0f24dfe3ff" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/manifest"
 

--- a/debian/rules
+++ b/debian/rules
@@ -80,13 +80,13 @@ override_dh_install:
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/manifest"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-x86.tar.gz" \
-		"bf8b4304c33cf9c90132b83ab912f6112bf6e15a2f06bb9dfbc46450f21c2a81" \
+		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-x86-1.tar.gz" \
+		"5352423fb1e88c4f168b9fd083a519b905ad8d4762cf053f7e4488155b90e1d7" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/jdk.tar.gz"
 
 	./scripts/fetch-file-from-artifactory.sh \
-		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-x86-manifest" \
-		"7e530c8863dd4a42a63237159365a0562c26afb6e74ca7bcd9e20fd7e02c11bf" \
+		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-x86-1-manifest" \
+		"3fff2e27a12f7d2aed8852f8f7c3d7d68fea4169e1c77b7652c0aa6f4bc8b7a2" \
 		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/manifest"
 
 	dh_install --autodest "debian/tmp/*"

--- a/debian/rules
+++ b/debian/rules
@@ -69,4 +69,24 @@ override_dh_install:
 		"bd3d0428a4eea7e38b73f4eac3168ead1595621273eaadbee45c16d3d192a0c9" \
 		"debian/tmp/usr/share/host-jdks/jdk/windows_x86/jdk17/manifest"
 
+	./scripts/fetch-file-from-artifactory.sh \
+		"sunos/jdk17/jdk17u-jdk-17.0.18-ga.tar.gz" \
+		"76f7bce8f56d0c06936d6f8eb524e371cd6e0dee86231444f7897298e5abe77e" \
+		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/jdk.tar.gz"
+
+	./scripts/fetch-file-from-artifactory.sh \
+		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-manifest" \
+		"573884e145756cc4d105f4c6964c5c0428ad0178dcd5d00c2e6288ce13ab1d66" \
+		"debian/tmp/usr/share/host-jdks/jdk/sunos_sparc/jdk17/manifest"
+
+	./scripts/fetch-file-from-artifactory.sh \
+		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-x86.tar.gz" \
+		"bf8b4304c33cf9c90132b83ab912f6112bf6e15a2f06bb9dfbc46450f21c2a81" \
+		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/jdk.tar.gz"
+
+	./scripts/fetch-file-from-artifactory.sh \
+		"sunos/jdk17/jdk17u-jdk-17.0.18-ga-x86-manifest" \
+		"7e530c8863dd4a42a63237159365a0562c26afb6e74ca7bcd9e20fd7e02c11bf" \
+		"debian/tmp/usr/share/host-jdks/jdk/sunos_x86/jdk17/manifest"
+
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
# Description
 To reintroduce Soalris to Delphix Engine add Solaris `SPARC` and `X86` entries to debian/rules.
 Fetches packaged jdk.tar.gz + manifest from Artifactory,  and installs to appliance.

app-gate: https://github.com/delphix/dlpx-app-gate/pull/4229
jdk-archiver: https://github.com/delphix/jdk-archiver/pull/18

# Links from Artifactory
SPARC:
https://artifactory.delphix.com/ui/repos/tree/General/delphix-java-packages/sunos/jdk17/jdk17u-jdk_sparcv9_solaris_17.0.19-manifest
https://artifactory.delphix.com/ui/repos/tree/General/delphix-java-packages/sunos/jdk17/jdk17u-jdk_sparcv9_solaris_17.0.19.tar.gz

x86:
https://artifactory.delphix.com/ui/repos/tree/General/delphix-java-packages/sunos/jdk17/jdk17u-jdk_x64_solaris_17.0.19-manifest
https://artifactory.delphix.com/ui/repos/tree/General/delphix-java-packages/sunos/jdk17/jdk17u-jdk_x64_solaris_17.0.19.tar.gz